### PR TITLE
Fix failing CI tests and reduce test output noise

### DIFF
--- a/src/security/pathValidator.ts
+++ b/src/security/pathValidator.ts
@@ -10,6 +10,13 @@ import { ConfigurationManager } from '../config/manager';
 
 export class PathValidator {
   /**
+   * Get the current platform (allows for easier testing)
+   */
+  private static getPlatform(): NodeJS.Platform {
+    return process.platform;
+  }
+
+  /**
    * Validates a file path against security boundaries
    * 
    * @param requestedPath - Path to validate
@@ -28,8 +35,8 @@ export class PathValidator {
       const isAllowed = config.security.allowedBasePaths.some(basePath => {
         const resolvedBase = path.resolve(basePath);
         // Use case-insensitive comparison on Windows
-        const normalizedPath = process.platform === 'win32' ? resolvedPath.toLowerCase() : resolvedPath;
-        const normalizedBase = process.platform === 'win32' ? resolvedBase.toLowerCase() : resolvedBase;
+        const normalizedPath = this.getPlatform() === 'win32' ? resolvedPath.toLowerCase() : resolvedPath;
+        const normalizedBase = this.getPlatform() === 'win32' ? resolvedBase.toLowerCase() : resolvedBase;
         const basePlusSlash = normalizedBase + path.sep;
         return normalizedPath.startsWith(basePlusSlash) || normalizedPath === normalizedBase;
       });
@@ -96,8 +103,8 @@ export class PathValidator {
       const isAllowed = config.security.allowedBasePaths.some(basePath => {
         const resolvedBase = path.resolve(basePath);
         // Use case-insensitive comparison on Windows
-        const normalizedPath = process.platform === 'win32' ? resolvedPath.toLowerCase() : resolvedPath;
-        const normalizedBase = process.platform === 'win32' ? resolvedBase.toLowerCase() : resolvedBase;
+        const normalizedPath = this.getPlatform() === 'win32' ? resolvedPath.toLowerCase() : resolvedPath;
+        const normalizedBase = this.getPlatform() === 'win32' ? resolvedBase.toLowerCase() : resolvedBase;
         const basePlusSlash = normalizedBase + path.sep;
         return normalizedPath.startsWith(basePlusSlash) || normalizedPath === normalizedBase;
       });

--- a/test/askFollowUp.test.ts
+++ b/test/askFollowUp.test.ts
@@ -29,7 +29,7 @@ describe('AskFollowUpTool Integration', () => {
     
     process.env.CONTEXT_OPT_ALLOWED_PATHS = process.cwd();
     process.env.CONTEXT_OPT_EXA_KEY = process.env.CONTEXT_OPT_EXA_KEY || 'test-key';
-    process.env.CONTEXT_OPT_LOG_LEVEL = 'info';
+    process.env.CONTEXT_OPT_LOG_LEVEL = 'error';
     
     await ConfigurationManager.loadConfiguration();
     tool = new AskFollowUpTool();

--- a/test/pathValidator.test.ts
+++ b/test/pathValidator.test.ts
@@ -197,9 +197,11 @@ describe('PathValidator', () => {
   });
 
   describe('Windows Case Sensitivity', () => {
+    let getPlatformSpy: jest.SpyInstance;
+    
     beforeEach(() => {
-      // Mock Windows platform
-      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      // Mock the getPlatform method to return 'win32'
+      getPlatformSpy = jest.spyOn(PathValidator as any, 'getPlatform').mockReturnValue('win32');
       
       mockedConfigManager.getConfig.mockReturnValue({
         security: {
@@ -256,8 +258,10 @@ describe('PathValidator', () => {
     });
 
     afterEach(() => {
-      // Reset platform
-      Object.defineProperty(process, 'platform', { value: process.platform, configurable: true });
+      // Restore the original getPlatform method
+      if (getPlatformSpy) {
+        getPlatformSpy.mockRestore();
+      }
     });
   });
 });

--- a/test/runAndExtract.integration.test.ts
+++ b/test/runAndExtract.integration.test.ts
@@ -29,7 +29,7 @@ describe('RunAndExtractTool Integration', () => {
     
     process.env.CONTEXT_OPT_ALLOWED_PATHS = process.cwd();
     process.env.CONTEXT_OPT_EXA_KEY = process.env.CONTEXT_OPT_EXA_KEY || 'test-key';
-    process.env.CONTEXT_OPT_LOG_LEVEL = 'info';
+    process.env.CONTEXT_OPT_LOG_LEVEL = 'error';
     
     await ConfigurationManager.loadConfiguration();
     tool = new RunAndExtractTool();

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -5,5 +5,11 @@
 // The MCP server now uses environment variables exclusively for configuration
 // No need to load .env files as the configuration system reads environment variables directly
 
+// Set quieter log level for tests to reduce console noise
+import { Logger } from '../src/utils/logger';
+
+// Set log level to 'error' during tests to suppress info/debug messages
+Logger.setLogLevel('error');
+
 // Extend Jest matchers
 import 'jest';


### PR DESCRIPTION
### Changes
- **Fixed PathValidator test failure**: Made platform checking more testable by adding `getPlatform()` method and using Jest spies instead of unreliable `process.platform` mocking
- **Reduced test console noise**: Changed log level from 'info' to 'error' in integration tests to suppress INFO messages during test execution

### Impact
- ✅ All tests now pass consistently across platforms (86/86)
- ✅ Clean test output without unnecessary log messages
- ✅ CI builds will pass on Ubuntu while still testing Windows-specific behavior
- 🔧 No functional changes to application behavior


fixes #61 