### PR TITLE
Implement npm Trusted Publishing with OIDC

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write  # for npm provenance (optional)
+  id-token: write  # Required for npm trusted publishing and provenance
 
 jobs:
   build-and-publish:
@@ -57,7 +57,6 @@ jobs:
 
       - name: Publish to npm
         if: steps.versions.outputs.published_version != steps.versions.outputs.package_version
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          echo "Publishing version ${{ steps.versions.outputs.package_version }} to npm using Trusted Publishing..."
           npm publish --access public --provenance


### PR DESCRIPTION
Fixes npm publish failures by replacing token-based authentication with npm's Trusted Publishing using OpenID Connect.

## Changes
- Updated GitHub Actions workflow to use OIDC authentication
- Removed dependency on `NPM_TOKEN` secret
- Updated permissions to include `id-token: write`
- Enhanced publish step messaging

## Setup Required
After merging, configure trusted publisher on npm:
1. Go to package settings on npmjs.com
2. Add GitHub Actions as trusted publisher
3. Remove `NPM_TOKEN` secret from repository

## Benefits
- ✅ No more OTP/2FA issues in CI/CD
- ✅ Enhanced security with short-lived tokens
- ✅ Automatic provenance attestations
- ✅ Zero npm token management

fixes: #68 