### PR TITLE
Switch to npm Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write  # for npm provenance (optional)
+  id-token: write  # Required for npm trusted publishing and provenance
 
 jobs:
   build-and-publish:
@@ -57,7 +57,6 @@ jobs:
 
       - name: Publish to npm
         if: steps.versions.outputs.published_version != steps.versions.outputs.package_version
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          echo "Publishing version ${{ steps.versions.outputs.package_version }} to npm using Trusted Publishing..."
           npm publish --access public --provenance

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,6 +13,7 @@ jobs:
     # Avoid publishing from forks
     if: github.repository_owner == 'malaksedarous'
     runs-on: ubuntu-latest
+    environment: npm-publish  # Optional: matches environment name in npm settings
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,7 +25,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
+
+      - name: Update npm (required for Trusted Publishing)
+        run: npm install -g npm@latest
+
+      - name: Show Node and npm versions
+        run: |
+          node -v
+          npm -v
 
       - name: Install dependencies
         run: npm ci
@@ -65,7 +74,7 @@ jobs:
           
           # Publish using Trusted Publishing with OIDC
           echo "🔄 Publishing with Trusted Publishing..."
-          if npm_output=$(npm publish --access public --provenance 2>&1); then
+          if npm_output=$(npm publish --access public 2>&1); then
             echo "✅ Published successfully with Trusted Publishing"
             echo "$npm_output"
           else

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
       - name: Install dependencies
@@ -59,4 +58,19 @@ jobs:
         if: steps.versions.outputs.published_version != steps.versions.outputs.package_version
         run: |
           echo "Publishing version ${{ steps.versions.outputs.package_version }} to npm using Trusted Publishing..."
-          npm publish --access public --provenance
+          echo "Repository: ${{ github.repository }}"
+          echo "Workflow: ${{ github.workflow }}"
+          echo "Actor: ${{ github.actor }}"
+          
+          # Publish using Trusted Publishing with OIDC
+          echo "🔄 Publishing with Trusted Publishing..."
+          if npm_output=$(npm publish --access public --provenance 2>&1); then
+            echo "✅ Published successfully with Trusted Publishing"
+            echo "$npm_output"
+          else
+            exit_code=$?
+            echo "❌ Trusted Publishing failed with exit code: $exit_code"
+            echo "Error output:"
+            echo "$npm_output"
+            exit $exit_code
+          fi


### PR DESCRIPTION
- Use GitHub OIDC for npm publish (no NPM_TOKEN)
- Grant id-token: write and set optional npm-publish environment
- Update npm to latest and print Node/npm versions
- Improve logs and failure handling; publish only on version change