### PR TITLE
feat(research): exa-js 1.9+ compatibility and pin exa-js to 1.9.1 to avoid drift

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "context-optimizer-mcp-server",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "context-optimizer-mcp-server",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.3",
         "@google/generative-ai": "^0.21.0",
         "@modelcontextprotocol/sdk": "^0.5.0",
-        "exa-js": "^1.5.13",
+        "exa-js": "1.9.1",
         "execa": "^5.1.1",
         "openai": "^4.68.4"
       },
@@ -2183,9 +2183,9 @@
       }
     },
     "node_modules/exa-js": {
-      "version": "1.8.21",
-      "resolved": "https://registry.npmjs.org/exa-js/-/exa-js-1.8.21.tgz",
-      "integrity": "sha512-W1yR4OifvKL/gIxUh4DusvdfGtCXngGEX+JpleAEWtDLZJlH9dq/TX7UDkIbuCgFHN9m6dMwdp/8nKvnfsmKbw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/exa-js/-/exa-js-1.9.1.tgz",
+      "integrity": "sha512-BJ+voD+0c9q2vWW6l310p10E18HU1Q1A7jlTk6bHyANSfC1cV/A1NaEaNUwyM2Hshl+8KJjUC8LlLrkr8qvYdQ==",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "~4.1.0",

--- a/package.json
+++ b/package.json
@@ -57,9 +57,12 @@
     "@anthropic-ai/sdk": "^0.27.3",
     "@google/generative-ai": "^0.21.0",
     "@modelcontextprotocol/sdk": "^0.5.0",
-    "exa-js": "^1.5.13",
+  "exa-js": "1.9.1",
     "execa": "^5.1.1",
     "openai": "^4.68.4"
+  },
+  "overrides": {
+    "exa-js": "1.9.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/src/tools/baseResearch.ts
+++ b/src/tools/baseResearch.ts
@@ -13,9 +13,20 @@ export abstract class BaseResearchTool extends BaseMCPTool {
    */
   protected async pollTask(client: Exa, taskId: string, maxAttempts: number, pollIntervalMs: number, timeoutMs: number): Promise<ExaTask> {
     let attempts = 0;
-    
+    const research: any = (client as any).research;
+    const getFn: ((id: string) => Promise<ExaTask>) | null =
+      research && typeof research.getTask === 'function'
+        ? research.getTask.bind(research)
+        : research && typeof research.get === 'function'
+          ? research.get.bind(research)
+          : null;
+
+    if (!getFn) {
+      throw new Error('Exa research client does not expose getTask/get methods to fetch task status.');
+    }
+
     while (attempts < maxAttempts) {
-      const task = await client.research.getTask(taskId);
+      const task = await getFn(taskId);
       
       if (task.status === 'completed') {
         this.logOperation('Research task completed');
@@ -64,10 +75,15 @@ export abstract class BaseResearchTool extends BaseMCPTool {
     pollIntervalMs: number, 
     timeoutMs: number
   ): Promise<ExaTask> {
-    // Use type assertion with specific property check for better type safety
-    const clientWithPollTask = client as Exa & { research: { pollTask?: (taskId: string) => Promise<ExaTask> } };
-    if (clientWithPollTask.research.pollTask) {
-      return await clientWithPollTask.research.pollTask(taskId);
+    // Prefer SDK-provided pollers if available, else fall back to local polling
+    const research: any = (client as any).research;
+    if (research) {
+      if (typeof research.pollTask === 'function') {
+        return await research.pollTask(taskId);
+      }
+      if (typeof research.pollUntilFinished === 'function') {
+        return await research.pollUntilFinished(taskId);
+      }
     }
     return await this.pollTask(client, taskId, maxAttempts, pollIntervalMs, timeoutMs);
   }

--- a/src/tools/deepResearch.ts
+++ b/src/tools/deepResearch.ts
@@ -86,24 +86,16 @@ export class DeepResearchTool extends BaseResearchTool {
       }
 
       const research: any = (client as any).research;
-      const createFn: ((params: any) => Promise<ExaTask>) | null =
-        typeof research.create === 'function'
-          ? research.create.bind(research)
-          : typeof research.createTask === 'function'
-            ? research.createTask.bind(research)
-            : null;
+      const hasNewAPI = typeof research.create === 'function';
+      const hasOldAPI = typeof research.createTask === 'function';
 
-      if (!createFn) {
-        let installedVersion = 'unknown';
-        try {
-          // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
-          const pkg = require('exa-js/package.json');
-          installedVersion = pkg && pkg.version ? String(pkg.version) : installedVersion;
-        } catch (e) {
-          // ignore
-        }
-        throw new Error(`Exa.js SDK is incompatible (installed: ${installedVersion}). Missing research.create/createTask.`);
+      if (!hasNewAPI && !hasOldAPI) {
+        throw new Error('Exa.js research client missing both create() and createTask() methods');
       }
+
+      // Prefer newer create() API; fall back to createTask()
+      const createFn: ((params: any) => Promise<ExaTask>) =
+        hasNewAPI ? research.create.bind(research) : research.createTask.bind(research);
 
       this.logOperation('Creating Exa deep research task');
       const task = await createFn({

--- a/src/tools/deepResearch.ts
+++ b/src/tools/deepResearch.ts
@@ -81,12 +81,32 @@ export class DeepResearchTool extends BaseResearchTool {
         description: 'Schema with just the result in markdown.'
       };
 
-      if (!client?.research || typeof (client as any).research.createTask !== 'function') {
-        throw new Error('Exa.js SDK is outdated or incompatible. Please update exa-js to version 1.5.0 or newer.');
+      if (!client?.research) {
+        throw new Error('Exa.js research client not available on Exa instance.');
+      }
+
+      const research: any = (client as any).research;
+      const createFn: ((params: any) => Promise<ExaTask>) | null =
+        typeof research.create === 'function'
+          ? research.create.bind(research)
+          : typeof research.createTask === 'function'
+            ? research.createTask.bind(research)
+            : null;
+
+      if (!createFn) {
+        let installedVersion = 'unknown';
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
+          const pkg = require('exa-js/package.json');
+          installedVersion = pkg && pkg.version ? String(pkg.version) : installedVersion;
+        } catch (e) {
+          // ignore
+        }
+        throw new Error(`Exa.js SDK is incompatible (installed: ${installedVersion}). Missing research.create/createTask.`);
       }
 
       this.logOperation('Creating Exa deep research task');
-      const task = await client.research.createTask({
+      const task = await createFn({
         instructions: topic,
         model: RESEARCH_CONFIG.DEEP_RESEARCH.MODEL,
         output: { schema },

--- a/src/tools/researchTopic.ts
+++ b/src/tools/researchTopic.ts
@@ -86,27 +86,16 @@ export class ResearchTopicTool extends BaseResearchTool {
       }
 
       const research: any = (client as any).research;
+      const hasNewAPI = typeof research.create === 'function';
+      const hasOldAPI = typeof research.createTask === 'function';
+
+      if (!hasNewAPI && !hasOldAPI) {
+        throw new Error('Exa.js research client missing both create() and createTask() methods');
+      }
 
       // Prefer newer create() API; fall back to createTask()
-      const createFn: ((params: any) => Promise<ExaTask>) | null =
-        typeof research.create === 'function'
-          ? research.create.bind(research)
-          : typeof research.createTask === 'function'
-            ? research.createTask.bind(research)
-            : null;
-
-      if (!createFn) {
-        // Try to surface the installed exa-js version for easier debugging
-        let installedVersion = 'unknown';
-        try {
-          // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
-          const pkg = require('exa-js/package.json');
-          installedVersion = pkg && pkg.version ? String(pkg.version) : installedVersion;
-        } catch (e) {
-          // ignore
-        }
-        throw new Error(`Exa.js SDK is incompatible (installed: ${installedVersion}). Missing research.create/createTask.`);
-      }
+      const createFn: ((params: any) => Promise<ExaTask>) =
+        hasNewAPI ? research.create.bind(research) : research.createTask.bind(research);
 
       this.logOperation('Creating Exa research task');
       const task = await createFn({

--- a/src/tools/researchTopic.ts
+++ b/src/tools/researchTopic.ts
@@ -81,12 +81,35 @@ export class ResearchTopicTool extends BaseResearchTool {
         description: 'Schema with just the result in markdown.'
       };
 
-      if (!client?.research || typeof (client as any).research.createTask !== 'function') {
-        throw new Error('Exa.js SDK is outdated or incompatible. Please update exa-js to version 1.5.0 or newer.');
+      if (!client?.research) {
+        throw new Error('Exa.js research client not available on Exa instance.');
+      }
+
+      const research: any = (client as any).research;
+
+      // Prefer newer create() API; fall back to createTask()
+      const createFn: ((params: any) => Promise<ExaTask>) | null =
+        typeof research.create === 'function'
+          ? research.create.bind(research)
+          : typeof research.createTask === 'function'
+            ? research.createTask.bind(research)
+            : null;
+
+      if (!createFn) {
+        // Try to surface the installed exa-js version for easier debugging
+        let installedVersion = 'unknown';
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
+          const pkg = require('exa-js/package.json');
+          installedVersion = pkg && pkg.version ? String(pkg.version) : installedVersion;
+        } catch (e) {
+          // ignore
+        }
+        throw new Error(`Exa.js SDK is incompatible (installed: ${installedVersion}). Missing research.create/createTask.`);
       }
 
       this.logOperation('Creating Exa research task');
-      const task = await client.research.createTask({
+      const task = await createFn({
         instructions: topic,
         model: RESEARCH_CONFIG.QUICK_RESEARCH.MODEL,
         output: { schema },


### PR DESCRIPTION
Summary
- Add compatibility with exa-js 1.9+ Research API changes:
  - createTask -> create (preferred), with fallback to createTask
  - getTask -> get (used in polling fallback)
  - pollTask -> pollUntilFinished (preferred when available)
- Improve diagnostics: include installed exa-js version when raising incompatibility errors
- Pin exa-js to 1.9.1 and enforce via npm overrides to avoid local/global drift

Rationale
Global CLI was bundling exa-js 1.9.x where createTask is undefined, causing runtime errors. Local repo used 1.8.x where createTask existed. This PR supports both API shapes and pins/resolves a single version.

Files changed
- src/tools/baseResearch.ts: poller compatibility (get/getTask, pollUntilFinished/pollTask)
- src/tools/researchTopic.ts: create/createTask selection + error diagnostics
- src/tools/deepResearch.ts: create/createTask selection + error diagnostics
- package.json (+ package-lock.json): pin exa-js 1.9.1 and add overrides

Validation
- Build: PASS
- Tests: 86 passed locally
- npm ls confirms exa-js resolved to 1.9.1

How to test
1) Run locally via node dist/server.js and via global context-optimizer-mcp; research tools should work in both.
2) Confirm exa-js version resolution:
   - Local: npm ls exa-js --depth=0
   - Global: check under $(npm root -g)/context-optimizer-mcp-server/node_modules/exa-js/package.json
