### PR TITLE
chore(release): v1.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "context-optimizer-mcp-server",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "context-optimizer-mcp-server",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "context-optimizer-mcp-server",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "context-optimizer-mcp-server",
-      "version": "1.0.3",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-optimizer-mcp-server",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Context optimization tools MCP server for AI coding assistants - compatible with GitHub Copilot, Cursor AI, and other MCP-supporting assistants",
   "main": "dist/server.js",
   "bin": {
@@ -57,7 +57,7 @@
     "@anthropic-ai/sdk": "^0.27.3",
     "@google/generative-ai": "^0.21.0",
     "@modelcontextprotocol/sdk": "^0.5.0",
-  "exa-js": "1.9.1",
+    "exa-js": "1.9.1",
     "execa": "^5.1.1",
     "openai": "^4.68.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-optimizer-mcp-server",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Context optimization tools MCP server for AI coding assistants - compatible with GitHub Copilot, Cursor AI, and other MCP-supporting assistants",
   "main": "dist/server.js",
   "bin": {


### PR DESCRIPTION
Release: v1.0.6

Summary
- Bump package version to 1.0.6
- All tests passing and build succeeds
- Tags pushed: v1.0.5, v1.0.6

Verification
- Build: PASS
- Tests: 86 passed locally

Next steps
- Merge this PR
- Publish to npm (optional): npm publish
- Update global install if desired: npm update -g context-optimizer-mcp-server