### PR TITLE
refactor(research): drop backward compatibility for Exa Research; use only create/get/pollUntilFinished

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "context-optimizer-mcp-server",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "context-optimizer-mcp-server",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-optimizer-mcp-server",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Context optimization tools MCP server for AI coding assistants - compatible with GitHub Copilot, Cursor AI, and other MCP-supporting assistants",
   "main": "dist/server.js",
   "bin": {

--- a/src/tools/baseResearch.ts
+++ b/src/tools/baseResearch.ts
@@ -14,19 +14,12 @@ export abstract class BaseResearchTool extends BaseMCPTool {
   protected async pollTask(client: Exa, taskId: string, maxAttempts: number, pollIntervalMs: number, timeoutMs: number): Promise<ExaTask> {
     let attempts = 0;
     const research: any = (client as any).research;
-    const getFn: ((id: string) => Promise<ExaTask>) | null =
-      research && typeof research.getTask === 'function'
-        ? research.getTask.bind(research)
-        : research && typeof research.get === 'function'
-          ? research.get.bind(research)
-          : null;
-
-    if (!getFn) {
-      throw new Error('Exa research client does not expose getTask/get methods to fetch task status.');
+    if (!research || typeof research.get !== 'function') {
+      throw new Error('Exa research client does not expose get() to fetch task status.');
     }
 
     while (attempts < maxAttempts) {
-      const task = await getFn(taskId);
+      const task = await research.get(taskId);
       
       if (task.status === 'completed') {
         this.logOperation('Research task completed');
@@ -75,12 +68,9 @@ export abstract class BaseResearchTool extends BaseMCPTool {
     pollIntervalMs: number, 
     timeoutMs: number
   ): Promise<ExaTask> {
-    // Prefer SDK-provided pollers if available, else fall back to local polling
+  // Prefer SDK-provided poller; else fall back to local polling using get()
     const research: any = (client as any).research;
     if (research) {
-      if (typeof research.pollTask === 'function') {
-        return await research.pollTask(taskId);
-      }
       if (typeof research.pollUntilFinished === 'function') {
         return await research.pollUntilFinished(taskId);
       }

--- a/src/tools/deepResearch.ts
+++ b/src/tools/deepResearch.ts
@@ -81,24 +81,13 @@ export class DeepResearchTool extends BaseResearchTool {
         description: 'Schema with just the result in markdown.'
       };
 
-      if (!client?.research) {
-        throw new Error('Exa.js research client not available on Exa instance.');
+      if (!client?.research || typeof (client as any).research.create !== 'function') {
+        throw new Error('Exa.js research client missing create() method');
       }
-
       const research: any = (client as any).research;
-      const hasNewAPI = typeof research.create === 'function';
-      const hasOldAPI = typeof research.createTask === 'function';
-
-      if (!hasNewAPI && !hasOldAPI) {
-        throw new Error('Exa.js research client missing both create() and createTask() methods');
-      }
-
-      // Prefer newer create() API; fall back to createTask()
-      const createFn: ((params: any) => Promise<ExaTask>) =
-        hasNewAPI ? research.create.bind(research) : research.createTask.bind(research);
 
       this.logOperation('Creating Exa deep research task');
-      const task = await createFn({
+  const task = await research.create({
         instructions: topic,
         model: RESEARCH_CONFIG.DEEP_RESEARCH.MODEL,
         output: { schema },

--- a/src/tools/researchTopic.ts
+++ b/src/tools/researchTopic.ts
@@ -81,24 +81,13 @@ export class ResearchTopicTool extends BaseResearchTool {
         description: 'Schema with just the result in markdown.'
       };
 
-      if (!client?.research) {
-        throw new Error('Exa.js research client not available on Exa instance.');
+      if (!client?.research || typeof (client as any).research.create !== 'function') {
+        throw new Error('Exa.js research client missing create() method');
       }
-
       const research: any = (client as any).research;
-      const hasNewAPI = typeof research.create === 'function';
-      const hasOldAPI = typeof research.createTask === 'function';
-
-      if (!hasNewAPI && !hasOldAPI) {
-        throw new Error('Exa.js research client missing both create() and createTask() methods');
-      }
-
-      // Prefer newer create() API; fall back to createTask()
-      const createFn: ((params: any) => Promise<ExaTask>) =
-        hasNewAPI ? research.create.bind(research) : research.createTask.bind(research);
 
       this.logOperation('Creating Exa research task');
-      const task = await createFn({
+  const task = await research.create({
         instructions: topic,
         model: RESEARCH_CONFIG.QUICK_RESEARCH.MODEL,
         output: { schema },

--- a/test/deepResearch.test.ts
+++ b/test/deepResearch.test.ts
@@ -139,8 +139,8 @@ describe('DeepResearchTool', () => {
 
       const mockExaClient = {
         research: {
-          createTask: jest.fn().mockResolvedValue({ id: 'task-123' }),
-          getTask: jest.fn().mockResolvedValue(mockTask)
+          create: jest.fn().mockResolvedValue({ id: 'task-123' }),
+          get: jest.fn().mockResolvedValue(mockTask)
         }
       };
       
@@ -153,7 +153,7 @@ describe('DeepResearchTool', () => {
       if (result.content[0]) {
         expect(result.content[0].text).toContain('Deep Research Results');
       }
-      expect(mockExaClient.research.createTask).toHaveBeenCalledWith({
+  expect(mockExaClient.research.create).toHaveBeenCalledWith({
         instructions: 'Complex research topic',
         model: 'exa-research-pro', // Should use pro model for deep research
         output: { 
@@ -185,8 +185,8 @@ describe('DeepResearchTool', () => {
       let callCount = 0;
       const mockExaClient = {
         research: {
-          createTask: jest.fn().mockResolvedValue({ id: 'task-123' }),
-          getTask: jest.fn().mockImplementation(() => {
+          create: jest.fn().mockResolvedValue({ id: 'task-123' }),
+          get: jest.fn().mockImplementation(() => {
             callCount++;
             // Simulate task running for a long time, then completing
             if (callCount < 18) { // 18 attempts * 10 seconds = 180 seconds
@@ -211,7 +211,7 @@ describe('DeepResearchTool', () => {
         expect(result.content[0].text).toContain('Long research completed');
       }
       // Should have made 18 calls (the max for deep research)
-      expect(mockExaClient.research.getTask).toHaveBeenCalledTimes(18);
+  expect(mockExaClient.research.get).toHaveBeenCalledTimes(18);
 
       // Restore original setTimeout
       global.setTimeout = originalSetTimeout;

--- a/test/researchTopic.test.ts
+++ b/test/researchTopic.test.ts
@@ -138,8 +138,8 @@ describe('ResearchTopicTool', () => {
 
       const mockExaClient = {
         research: {
-          createTask: jest.fn().mockResolvedValue({ id: 'task-123' }),
-          getTask: jest.fn().mockResolvedValue(mockTask)
+          create: jest.fn().mockResolvedValue({ id: 'task-123' }),
+          get: jest.fn().mockResolvedValue(mockTask)
         }
       };
       
@@ -152,7 +152,7 @@ describe('ResearchTopicTool', () => {
       if (result.content[0]) {
         expect(result.content[0].text).toContain('Quick Research Results');
       }
-      expect(mockExaClient.research.createTask).toHaveBeenCalledWith({
+  expect(mockExaClient.research.create).toHaveBeenCalledWith({
         instructions: 'Simple research topic',
         model: 'exa-research', // Should use standard model for quick research
         output: { 
@@ -184,8 +184,8 @@ describe('ResearchTopicTool', () => {
       let callCount = 0;
       const mockExaClient = {
         research: {
-          createTask: jest.fn().mockResolvedValue({ id: 'task-123' }),
-          getTask: jest.fn().mockImplementation(() => {
+          create: jest.fn().mockResolvedValue({ id: 'task-123' }),
+          get: jest.fn().mockImplementation(() => {
             callCount++;
             // Simulate task running for exactly 120 seconds (12 attempts * 10 seconds)
             if (callCount < 12) {
@@ -210,7 +210,7 @@ describe('ResearchTopicTool', () => {
         expect(result.content[0].text).toContain('Quick research completed');
       }
       // Should have made 12 calls (the max for quick research)
-      expect(mockExaClient.research.getTask).toHaveBeenCalledTimes(12);
+  expect(mockExaClient.research.get).toHaveBeenCalledTimes(12);
 
       // Restore original setTimeout
       global.setTimeout = originalSetTimeout;


### PR DESCRIPTION
Summary
- Remove legacy Exa Research API paths (createTask/getTask/pollTask)
- Use only latest SDK: research.create, research.get, research.pollUntilFinished
- Simplify polling fallback to rely on research.get when pollUntilFinished missing
- Update tests to mock the latest API names

Rationale
Exa servers and SDK docs favor the new Research API surface. Dropping backward-compat avoids drift and reduces maintenance.

Verification
- Build: PASS
- Tests: 86 passed locally

Follow-ups
- If desired, remove any docs mentioning the old method names.
- Optionally add exponential backoff for polling retry resilience.